### PR TITLE
Make limit work in SQL Server 2008 by encoding it as TOP

### DIFF
--- a/test/mssql_ecto/select_test.exs
+++ b/test/mssql_ecto/select_test.exs
@@ -147,7 +147,7 @@ defmodule MssqlEcto.SelectTest do
 
   test "limit and offset" do
     query = Schema |> limit([r], 3) |> select([], true) |> normalize
-    assert SQL.all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 OFFSET 0 ROWS FETCH NEXT 3 ROWS ONLY}
+    assert SQL.all(query) == ~s{SELECT TOP 3 'TRUE' FROM "schema" AS s0}
 
     query = Schema |> offset([r], 5) |> select([], true) |> normalize
     assert SQL.all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 OFFSET 5 ROWS}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adapter now uses `SELECT TOP X FROM...` syntax when a limit exists without offset, rather than
the `OFFSET 0 ROWS FETCH NEXT X ROWS ONLY`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OFFSET/FETCH was added in SQL Server 2012 so depending on that syntax means that we couldn't
have limit arguments in earlier versions despite limits without offset being supported (via TOP).

This PR closes https://github.com/findmypast-oss/mssql_ecto/issues/3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Full test suite ran.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
