### PR TITLE
Adding clarity to readme on how to use non-ODBC drivers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ config :my_app, MyApp.Repo,
   database: "sql_server_db",
   username: "bob",
   password: "mySecurePa$$word",
-  hostname: "localhost"
+  hostname: "localhost",
+  odbc_driver: "{SQL Server Native Client 11.0}" # this will have to be set if not using ODBC driver
 ```
 
 ## Type Mappings


### PR DESCRIPTION
Adding clarity to readme on how to use non-ODBC drivers.

Relates to #6