### PR TITLE
Make storage logic work

### DIFF
--- a/integration/mssql/test_helper.exs
+++ b/integration/mssql/test_helper.exs
@@ -76,8 +76,8 @@ end
 {:ok, _} = MssqlEcto.ensure_all_started(TestRepo, :temporary)
 
 # Load up the repository, start it, and run migrations
-_   = MssqlEcto.Storage.storage_down(TestRepo.config())
-:ok = MssqlEcto.Storage.storage_up(TestRepo.config())
+_   = MssqlEcto.storage_down(TestRepo.config())
+:ok = MssqlEcto.storage_up(TestRepo.config())
 
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link

--- a/lib/mssql_ecto.ex
+++ b/lib/mssql_ecto.ex
@@ -1,9 +1,12 @@
 defmodule MssqlEcto do
   @moduledoc false
+  @behaviour Ecto.Adapter.Storage
 
   use Ecto.Adapters.SQL, :mssqlex
 
   alias MssqlEcto.Migration
+  alias MssqlEcto.Storage
+  alias MssqlEcto.Structure
 
   import MssqlEcto.Type, only: [encode: 2, decode: 2]
 
@@ -18,6 +21,14 @@ defmodule MssqlEcto do
   def loaders({:embed, _} = type, _), do: [&Ecto.Adapters.SQL.load_embed(type, &1)]
   def loaders(ecto_type, type),       do: [&(decode(&1, ecto_type)), type]
 
-  def supports_ddl_transaction?,      do: Migration.supports_ddl_transaction?
+  ## Migration
+  def supports_ddl_transaction?, do: Migration.supports_ddl_transaction?
 
+  ## Storage
+  def storage_up(opts), do: Storage.storage_up(opts)
+  def storage_down(opts), do: Storage.storage_down(opts)
+
+  ## Structure
+  def structure_dump(default, config), do: Structure.structure_dump(default, config)
+  def structure_load(default, config), do: Structure.structure_load(default, config)
 end

--- a/lib/mssql_ecto/connection.ex
+++ b/lib/mssql_ecto/connection.ex
@@ -1,8 +1,5 @@
 defmodule MssqlEcto.Connection do
   alias Mssqlex.Query
-  alias MssqlEcto.Migration
-  alias MssqlEcto.Storage
-  alias MssqlEcto.Structure
   alias MssqlEcto.Query, as: SQL
 
   @typedoc "The prepared query which is an SQL command"
@@ -153,14 +150,5 @@ defmodule MssqlEcto.Connection do
     do: SQL.delete(prefix, table, filters, returning)
 
   ## Migration
-  def execute_ddl(command), do: Migration.execute_ddl(command)
-  def supports_ddl_transaction?, do: Migration.supports_ddl_transaction?
-
-  ## Storage
-  def storage_up(opts), do: Storage.storage_up(opts)
-  def storage_down(opts), do: Storage.storage_down(opts)
-
-  ## Structure
-  def structure_dump(default, config), do: Structure.structure_dump(default, config)
-  def structure_load(default, config), do: Structure.structure_load(default, config)
+  def execute_ddl(command), do: MssqlEcto.Migration.execute_ddl(command)
 end


### PR DESCRIPTION
The storage methods (`storage_up, storage_down, structure_dump, structure_load`) were erroneously implemented in `MssqlEcto.Connection` rather than `MssqlEcto`, causing them to not work with existing tooling.

## Motivation and Context
Closes https://github.com/findmypast-oss/mssql_ecto/issues/8

## How Has This Been Tested?
All tests passing.
Tested by calling `ecto.create` on an existing project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
