### PR TITLE
Corrected error codes expected from Mssqlex for storage up and down

### DIFF
--- a/lib/mssql_ecto/storage.ex
+++ b/lib/mssql_ecto/storage.ex
@@ -16,7 +16,7 @@ defmodule MssqlEcto.Storage do
     case run_query(command, opts) do
       {:ok, _} ->
         :ok
-      {:error, %{odbc_code: :base_table_or_view_already_exists}} ->
+      {:error, %{odbc_code: :database_already_exists}} ->
         {:error, :already_up}
       {:error, error} ->
         {:error, Exception.message(error)}
@@ -35,7 +35,7 @@ defmodule MssqlEcto.Storage do
     case run_query(command, opts) do
       {:ok, _} ->
         :ok
-      {:error, %{mssqlserver: %{code: :invalid_catalog_name}}} ->
+      {:error, %{odbc_code: :base_table_or_view_not_found}} ->
         {:error, :already_down}
       {:error, error} ->
         {:error, Exception.message(error)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made the adapter translate the error codes from Mssqlex so that tools like `mix ecto.create` can tell when a command failed due to the database already being up and not error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should close https://github.com/findmypast-oss/mssql_ecto/issues/8

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passing.
Manually tested with a new test phoenix project as described in https://github.com/findmypast-oss/mssql_ecto/issues/8

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
