### PR TITLE
Install correct MS ODBC package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends apt-transport-https
 
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-&& curl https://packages.microsoft.com/config/debian/8/prod.list | tee -a /etc/apt/sources.list.d/mssql-release.list \
+&& curl https://packages.microsoft.com/config/debian/9/prod.list | tee -a /etc/apt/sources.list.d/mssql-release.list \
 && apt-get update \
-&& ACCEPT_EULA=Y apt-get install msodbcsql -y \
+&& ACCEPT_EULA=Y apt-get install msodbcsql17 -y \
 && apt-get install unixodbc-dev -y
 
 # --- APP INSTALL ---


### PR DESCRIPTION
## Description
Install **msodbcsql17** for Debian **9**

## Motivation and Context
Running the tests failed, ODBC 17 was not found.

[Microsoft site](https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server) states:
> If you installed the v17 msodbcsql package that was briefly available, you should remove it before installing the msodbcsql17 package. This will avoid conflicts. The msodbcsql17 package can be installed side by side with the msodbcsql v13 package.

## How Has This Been Tested?
Built a new image, ran `docker-compose run mssql_ecto mix test`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
